### PR TITLE
add flush interface to logger/sink

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -10,6 +10,7 @@ const STACK_TRACE_BUFFER_SIZE = 1024 * 100
 
 type Logger interface {
 	RegisterSink(Sink)
+	Flush()
 	Debug(task, action, description string, data ...Data)
 	Info(task, action, description string, data ...Data)
 	Error(task, action, description string, err error, data ...Data)
@@ -30,6 +31,12 @@ func NewLogger(component string) Logger {
 
 func (l *logger) RegisterSink(sink Sink) {
 	l.sinks = append(l.sinks, sink)
+}
+
+func (l *logger) Flush() {
+	for _, sink := range l.sinks {
+		sink.Flush()
+	}
 }
 
 func (l *logger) Debug(task, action, description string, data ...Data) {

--- a/test_sink.go
+++ b/test_sink.go
@@ -23,6 +23,7 @@ func NewTestLogger(component string) *TestLogger {
 type TestSink struct {
 	contents []byte
 	lock     *sync.Mutex
+	flushed  int
 }
 
 func NewTestSink() *TestSink {
@@ -36,6 +37,20 @@ func (l *TestSink) Log(level LogLevel, p []byte) {
 	defer l.lock.Unlock()
 
 	l.contents = append(l.contents, p...)
+}
+
+func (l *TestSink) Flush() {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	l.flushed++
+}
+
+func (l *TestSink) Flushed() int {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	return l.flushed
 }
 
 func (l *TestSink) Buffer() *bytes.Buffer {

--- a/writer_sink_test.go
+++ b/writer_sink_test.go
@@ -65,6 +65,16 @@ var _ = Describe("WriterSink", func() {
 
 			close(done)
 		})
+
+		It("waits for it when flushing", func() {
+			sink.Log(lager.INFO, []byte("hello world"))
+
+			t1 := time.Now()
+
+			sink.Flush()
+
+			Ω(time.Now().Sub(t1)).Should(BeNumerically(">", 500 * time.Millisecond))
+		})
 	})
 
 	Context("when logging from multiple threads", func() {
@@ -133,6 +143,6 @@ func NewSlowWriter() *slowWriter {
 }
 
 func (writer *slowWriter) Write(p []byte) (n int, err error) {
-	time.Sleep(100 * time.Minute)
+	time.Sleep(1 * time.Second)
 	return 0, nil
 }


### PR DESCRIPTION
This adds Flush() to the interface, which will wait for in-flight logs to finish.

Honestly though I think we should just block on writing and shuck all the syslog logic out of here. It's like one line in the ctl scripts to hook up syslog. Considering we can remove the flag configuring the syslog name, it's a net 0.

Before:

```
    exec /var/vcap/packages/converger/bin/converger \
      -syslogName=vcap.converger \
      -etcdCluster=<%= p("etcd.machines").map{|addr| "\"http://#{addr}:4001\""}.join(",")%> \
      1>>$LOG_DIR/converger.stdout.log \
      2>>$LOG_DIR/converger.stderr.log
```

After:

```
    exec /var/vcap/packages/converger/bin/converger \
      -etcdCluster=<%= p("etcd.machines").map{|addr| "\"http://#{addr}:4001\""}.join(",")%> \
      1> >(tee -a $LOG_DIR/converger.stdout.log | logger -t vcap.converger) \
      2>>$LOG_DIR/converger.stderr.log
```

...and then we're not depending on Go's syslog library being compatible with the system's. Which I'm not sure is the case unless we vendor syslog like gosteno did.
