### PR TITLE
Don't panic if message.Data can't be converted to json

### DIFF
--- a/models.go
+++ b/models.go
@@ -1,6 +1,9 @@
 package lager
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type LogLevel int
 
@@ -24,7 +27,13 @@ type LogFormat struct {
 func (log LogFormat) ToJSON() []byte {
 	content, err := json.Marshal(log)
 	if err != nil {
-		panic(err)
+		if _, ok := err.(*json.UnsupportedTypeError); ok {
+			log.Data = map[string]interface{}{"lager serialisation error": err.Error(), "data_dump": fmt.Sprintf("%#v", log.Data)}
+			content, err = json.Marshal(log)
+		}
+		if err != nil {
+			panic(err)
+		}
 	}
 	return content
 }

--- a/writer_sink_test.go
+++ b/writer_sink_test.go
@@ -1,6 +1,7 @@
 package lager_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
 	"strings"
@@ -35,6 +36,32 @@ var _ = Describe("WriterSink", func() {
 		It("writes to the given writer", func() {
 			Expect(writer.Copy()).To(MatchJSON(`{"message":"hello world","log_level":1,"timestamp":"","source":"","data":null}`))
 		})
+	})
+
+	Context("when a unserializable object is passed into data", func() {
+		BeforeEach(func() {
+			sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: "hello world", Data: map[string]interface{}{"some_key": func() {}}})
+		})
+
+		It("Logs the serialization error", func() {
+			message := map[string]interface{}{}
+			json.Unmarshal(writer.Copy(), &message)
+			Expect(message["message"]).To(Equal("hello world"))
+			Expect(message["log_level"]).To(Equal(float64(1)))
+			Expect(message["data"].(map[string]interface{})["lager serialisation error"]).To(Equal("json: unsupported type: func()"))
+			Expect(message["data"].(map[string]interface{})["data_dump"]).ToNot(BeEmpty())
+		})
+
+		Measure("should be efficient", func(b Benchmarker) {
+			runtime := b.Time("runtime", func() {
+				for i := 0; i < 5000; i++ {
+					sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: "hello world", Data: map[string]interface{}{"some_key": func() {}}})
+					Expect(writer.Copy()).ToNot(BeEmpty())
+				}
+			})
+
+			Expect(runtime.Seconds()).To(BeNumerically("<", 1), "logging shouldn't take too long.")
+		}, 1)
 	})
 
 	Context("when logging below the minimum log level", func() {


### PR DESCRIPTION
Scenario:
When LogFormat.Data is assigned an object that cannot be converted to a json, like channel, complex, and function values.

Current behaviour:
It panics 

Expected behaviour:
Should not panic 

What should be logged if the json serialization fails is a bit of a puzzle. If the json serialization fails, it can be only because of the Data attribute as all of the other fields on LogFormat can always be encoded into json. I think the options are:
1. Don't log anything
2. Log the message without the `Data` attribute.
3. Log the message by replacing data with the error that occurred while marshalling data.

Option 3 is chosen as its the most verbose, but I think it might be confusing for the reader, as the message can be mistaken for an error being logged, rather than a error while logging.

Thoughts?
