### PR TITLE
Add RedactingWriterSink class to lager for log filtering

### DIFF
--- a/json_redacter.go
+++ b/json_redacter.go
@@ -1,0 +1,100 @@
+package lager
+
+import (
+	"encoding/json"
+	"regexp"
+)
+
+
+const awsAccessKeyIDPattern = `AKIA[A-Z0-9]{16}`
+const awsSecretAccessKeyPattern = `KEY["']?\s*(?::|=>|=)\s*["']?[A-Z0-9/\+=]{40}["']?`
+const cryptMD5Pattern = `\$1\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{22}`
+const cryptSHA256Pattern = `\$5\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{43}`
+const cryptSHA512Pattern = `\$6\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{86}`
+const privateKeyHeaderPattern = `-----BEGIN(.*)PRIVATE KEY-----`
+
+type JsonRedacter struct {
+	keyMatchers []*regexp.Regexp
+	valueMatchers []*regexp.Regexp
+}
+
+func NewJsonRedacter(keyPatterns []string, valuePatterns []string) (*JsonRedacter, error) {
+	if keyPatterns == nil {
+		keyPatterns = []string{"[Pp]wd","[Pp]ass"}
+	}
+	if valuePatterns == nil {
+		valuePatterns = []string{awsAccessKeyIDPattern, awsSecretAccessKeyPattern, cryptMD5Pattern, cryptSHA256Pattern, cryptSHA512Pattern, privateKeyHeaderPattern}
+	}
+	ret := &JsonRedacter{}
+	for _ ,v := range keyPatterns {
+		r, err := regexp.Compile(v)
+		if err != nil {
+			return nil, err
+		}
+		ret.keyMatchers = append(ret.keyMatchers, r)
+	}
+	for _ ,v := range valuePatterns {
+		r, err := regexp.Compile(v)
+		if err != nil {
+			return nil, err
+		}
+		ret.valueMatchers = append(ret.valueMatchers, r)
+	}
+	return ret, nil
+}
+
+func (r JsonRedacter) Redact(data []byte) ([]byte, error) {
+	var jsonBlob interface{}
+	err := json.Unmarshal(data, &jsonBlob)
+	if err != nil {
+		return nil, err
+	}
+	r.redactValue(&jsonBlob)
+
+	data, err = json.Marshal(jsonBlob)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (r JsonRedacter) redactValue(data *interface{}) interface{} {
+	if data == nil {
+		return data
+	}
+
+	if a, ok := (*data).([]interface{}); ok {
+		r.redactArray(&a)
+	} else if m, ok := (*data).(map[string]interface{}); ok {
+		r.redactObject(&m)
+	} else if s, ok := (*data).(string); ok {
+		for _, m := range r.valueMatchers {
+			if m.MatchString(s) {
+				(*data) = "*REDACTED*"
+				break
+			}
+		}
+	}
+	return (*data)
+}
+
+func (r JsonRedacter) redactArray(data *[]interface{}) {
+	for i, _ := range *data {
+		r.redactValue(&((*data)[i]))
+	}
+}
+
+func (r JsonRedacter) redactObject(data *map[string]interface{}) {
+	for k, v := range *data {
+		for _, m := range r.keyMatchers {
+			if m.MatchString(k) {
+				(*data)[k] = "*REDACTED*"
+				break
+			}
+		}
+		if (*data)[k] != "*REDACTED*" {
+			(*data)[k] = r.redactValue(&v)
+		}
+	}
+}

--- a/json_redacter.go
+++ b/json_redacter.go
@@ -13,19 +13,19 @@ const cryptSHA256Pattern = `\$5\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{43}`
 const cryptSHA512Pattern = `\$6\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{86}`
 const privateKeyHeaderPattern = `-----BEGIN(.*)PRIVATE KEY-----`
 
-type JsonRedacter struct {
+type JSONRedacter struct {
 	keyMatchers []*regexp.Regexp
 	valueMatchers []*regexp.Regexp
 }
 
-func NewJsonRedacter(keyPatterns []string, valuePatterns []string) (*JsonRedacter, error) {
+func NewJSONRedacter(keyPatterns []string, valuePatterns []string) (*JSONRedacter, error) {
 	if keyPatterns == nil {
 		keyPatterns = []string{"[Pp]wd","[Pp]ass"}
 	}
 	if valuePatterns == nil {
 		valuePatterns = []string{awsAccessKeyIDPattern, awsSecretAccessKeyPattern, cryptMD5Pattern, cryptSHA256Pattern, cryptSHA512Pattern, privateKeyHeaderPattern}
 	}
-	ret := &JsonRedacter{}
+	ret := &JSONRedacter{}
 	for _ ,v := range keyPatterns {
 		r, err := regexp.Compile(v)
 		if err != nil {
@@ -43,7 +43,7 @@ func NewJsonRedacter(keyPatterns []string, valuePatterns []string) (*JsonRedacte
 	return ret, nil
 }
 
-func (r JsonRedacter) Redact(data []byte) []byte {
+func (r JSONRedacter) Redact(data []byte) []byte {
 	var jsonBlob interface{}
 	err := json.Unmarshal(data, &jsonBlob)
 	if err != nil {
@@ -59,7 +59,7 @@ func (r JsonRedacter) Redact(data []byte) []byte {
 	return data
 }
 
-func (r JsonRedacter) redactValue(data *interface{}) interface{} {
+func (r JSONRedacter) redactValue(data *interface{}) interface{} {
 	if data == nil {
 		return data
 	}
@@ -79,13 +79,13 @@ func (r JsonRedacter) redactValue(data *interface{}) interface{} {
 	return (*data)
 }
 
-func (r JsonRedacter) redactArray(data *[]interface{}) {
+func (r JSONRedacter) redactArray(data *[]interface{}) {
 	for i, _ := range *data {
 		r.redactValue(&((*data)[i]))
 	}
 }
 
-func (r JsonRedacter) redactObject(data *map[string]interface{}) {
+func (r JSONRedacter) redactObject(data *map[string]interface{}) {
 	for k, v := range *data {
 		for _, m := range r.keyMatchers {
 			if m.MatchString(k) {

--- a/json_redacter_test.go
+++ b/json_redacter_test.go
@@ -8,15 +8,15 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Json Redacter", func() {
+var _ = Describe("JSON Redacter", func() {
 	var (
 	  resp []byte
 	  err error
-	  jsonRedacter *lager.JsonRedacter
+	  jsonRedacter *lager.JSONRedacter
 	)
 
 	BeforeEach(func() {
-		jsonRedacter, err = lager.NewJsonRedacter(nil, []string{`amazonkey`, `AKIA[A-Z0-9]{16}`})
+		jsonRedacter, err = lager.NewJSONRedacter(nil, []string{`amazonkey`, `AKIA[A-Z0-9]{16}`})
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/json_redacter_test.go
+++ b/json_redacter_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = FDescribe("Json Redacter", func() {
+var _ = Describe("Json Redacter", func() {
 	var (
 	  resp []byte
 	  err error
@@ -22,10 +22,7 @@ var _ = FDescribe("Json Redacter", func() {
 
 	Context("when called with normal (non-secret) json", func() {
 		BeforeEach(func(){
-			resp, err  = jsonRedacter.Redact([]byte(`{"foo":"bar"}`))
-		})
-		It("should succeed", func() {
-			Expect(err).NotTo(HaveOccurred())
+			resp = jsonRedacter.Redact([]byte(`{"foo":"bar"}`))
 		})
 		It("should return the same text", func(){
 			Expect(resp).To(Equal([]byte(`{"foo":"bar"}`)))
@@ -34,55 +31,50 @@ var _ = FDescribe("Json Redacter", func() {
 
 	Context("when called with secrets inside the json", func() {
 		BeforeEach(func() {
-			resp, err = jsonRedacter.Redact([]byte(`{"foo":"fooval","password":"secret!","something":"AKIA1234567890123456"}`))
+			resp = jsonRedacter.Redact([]byte(`{"foo":"fooval","password":"secret!","something":"AKIA1234567890123456"}`))
 		})
 
 		It("should redact the secrets", func() {
-			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).To(Equal([]byte(`{"foo":"fooval","password":"*REDACTED*","something":"*REDACTED*"}`)))
 		})
 	})
 
 	Context("when a password flag is specified", func() {
 		BeforeEach(func() {
-			resp, err = jsonRedacter.Redact([]byte(`{"abcPwd":"abcd","password":"secret!","userpass":"fooval"}`))
+			resp = jsonRedacter.Redact([]byte(`{"abcPwd":"abcd","password":"secret!","userpass":"fooval"}`))
 		})
 
 		It("should redact the secrets", func() {
-			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).To(Equal([]byte(`{"abcPwd":"*REDACTED*","password":"*REDACTED*","userpass":"*REDACTED*"}`)))
 		})
 	})
 
 	Context("when called with an array of objects with a secret", func() {
 		BeforeEach(func() {
-			resp, err = jsonRedacter.Redact([]byte(`[{"foo":"fooval","password":"secret!","something":"amazonkey"}]`))
+			resp = jsonRedacter.Redact([]byte(`[{"foo":"fooval","password":"secret!","something":"amazonkey"}]`))
 		})
 
 		It("should redact the secrets", func() {
-			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).To(Equal([]byte(`[{"foo":"fooval","password":"*REDACTED*","something":"*REDACTED*"}]`)))
 		})
 	})
 
 	Context("when called with a private key inside an array of strings", func() {
 		BeforeEach(func() {
-			resp, err = jsonRedacter.Redact([]byte(`["foo", "secret!", "amazonkey"]`))
+			resp = jsonRedacter.Redact([]byte(`["foo", "secret!", "amazonkey"]`))
 		})
 
 		It("should redact the amazonkey", func() {
-			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).To(Equal([]byte(`["foo","secret!","*REDACTED*"]`)))
 		})
 	})
 
 	Context("when called with a private key inside a nested object", func() {
 		BeforeEach(func() {
-			resp, err = jsonRedacter.Redact([]byte(`{"foo":"fooval", "secret_stuff": {"password": "secret!"}}`))
+			resp = jsonRedacter.Redact([]byte(`{"foo":"fooval", "secret_stuff": {"password": "secret!"}}`))
 		})
 
 		It("should redact the amazonkey", func() {
-			Expect(err).NotTo(HaveOccurred())
 			Expect(resp).To(Equal([]byte(`{"foo":"fooval","secret_stuff":{"password":"*REDACTED*"}}`)))
 		})
 	})

--- a/json_redacter_test.go
+++ b/json_redacter_test.go
@@ -1,0 +1,89 @@
+package lager_test
+
+
+import (
+	"code.cloudfoundry.org/lager"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("Json Redacter", func() {
+	var (
+	  resp []byte
+	  err error
+	  jsonRedacter *lager.JsonRedacter
+	)
+
+	BeforeEach(func() {
+		jsonRedacter, err = lager.NewJsonRedacter(nil, []string{`amazonkey`, `AKIA[A-Z0-9]{16}`})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when called with normal (non-secret) json", func() {
+		BeforeEach(func(){
+			resp, err  = jsonRedacter.Redact([]byte(`{"foo":"bar"}`))
+		})
+		It("should succeed", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should return the same text", func(){
+			Expect(resp).To(Equal([]byte(`{"foo":"bar"}`)))
+		})
+	})
+
+	Context("when called with secrets inside the json", func() {
+		BeforeEach(func() {
+			resp, err = jsonRedacter.Redact([]byte(`{"foo":"fooval","password":"secret!","something":"AKIA1234567890123456"}`))
+		})
+
+		It("should redact the secrets", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(Equal([]byte(`{"foo":"fooval","password":"*REDACTED*","something":"*REDACTED*"}`)))
+		})
+	})
+
+	Context("when a password flag is specified", func() {
+		BeforeEach(func() {
+			resp, err = jsonRedacter.Redact([]byte(`{"abcPwd":"abcd","password":"secret!","userpass":"fooval"}`))
+		})
+
+		It("should redact the secrets", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(Equal([]byte(`{"abcPwd":"*REDACTED*","password":"*REDACTED*","userpass":"*REDACTED*"}`)))
+		})
+	})
+
+	Context("when called with an array of objects with a secret", func() {
+		BeforeEach(func() {
+			resp, err = jsonRedacter.Redact([]byte(`[{"foo":"fooval","password":"secret!","something":"amazonkey"}]`))
+		})
+
+		It("should redact the secrets", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(Equal([]byte(`[{"foo":"fooval","password":"*REDACTED*","something":"*REDACTED*"}]`)))
+		})
+	})
+
+	Context("when called with a private key inside an array of strings", func() {
+		BeforeEach(func() {
+			resp, err = jsonRedacter.Redact([]byte(`["foo", "secret!", "amazonkey"]`))
+		})
+
+		It("should redact the amazonkey", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(Equal([]byte(`["foo","secret!","*REDACTED*"]`)))
+		})
+	})
+
+	Context("when called with a private key inside a nested object", func() {
+		BeforeEach(func() {
+			resp, err = jsonRedacter.Redact([]byte(`{"foo":"fooval", "secret_stuff": {"password": "secret!"}}`))
+		})
+
+		It("should redact the amazonkey", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).To(Equal([]byte(`{"foo":"fooval","secret_stuff":{"password":"*REDACTED*"}}`)))
+		})
+	})
+})

--- a/lagerflags/lagerflags.go
+++ b/lagerflags/lagerflags.go
@@ -37,14 +37,18 @@ func AddFlags(flagSet *flag.FlagSet) {
 }
 
 func New(component string) (lager.Logger, *lager.ReconfigurableSink) {
-	return newLogger(component, minLogLevel)
+	return newLogger(component, minLogLevel, lager.NewWriterSink(os.Stdout, lager.DEBUG))
+}
+
+func NewFromSink(component string, sink lager.Sink) (lager.Logger, *lager.ReconfigurableSink) {
+	return newLogger(component, minLogLevel, sink)
 }
 
 func NewFromConfig(component string, config LagerConfig) (lager.Logger, *lager.ReconfigurableSink) {
-	return newLogger(component, config.LogLevel)
+	return newLogger(component, config.LogLevel, lager.NewWriterSink(os.Stdout, lager.DEBUG))
 }
 
-func newLogger(component, minLogLevel string) (lager.Logger, *lager.ReconfigurableSink) {
+func newLogger(component, minLogLevel string, inSink lager.Sink) (lager.Logger, *lager.ReconfigurableSink) {
 	var minLagerLogLevel lager.LogLevel
 
 	switch minLogLevel {
@@ -62,7 +66,7 @@ func newLogger(component, minLogLevel string) (lager.Logger, *lager.Reconfigurab
 
 	logger := lager.NewLogger(component)
 
-	sink := lager.NewReconfigurableSink(lager.NewWriterSink(os.Stdout, lager.DEBUG), minLagerLogLevel)
+	sink := lager.NewReconfigurableSink(inSink, minLagerLogLevel)
 	logger.RegisterSink(sink)
 
 	return logger, sink

--- a/redacting_writer_sink.go
+++ b/redacting_writer_sink.go
@@ -9,11 +9,11 @@ type redactingWriterSink struct {
 	writer      io.Writer
 	minLogLevel LogLevel
 	writeL      *sync.Mutex
-	jsonRedacter *JsonRedacter
+	jsonRedacter *JSONRedacter
 }
 
 func NewRedactingWriterSink(writer io.Writer, minLogLevel LogLevel, keyPatterns []string, valuePatterns []string) (Sink, error) {
-	jsonRedacter, err := NewJsonRedacter(keyPatterns, valuePatterns)
+	jsonRedacter, err := NewJSONRedacter(keyPatterns, valuePatterns)
 	if err != nil {
 		return nil, err
 	}

--- a/redacting_writer_sink.go
+++ b/redacting_writer_sink.go
@@ -1,0 +1,43 @@
+package lager
+
+import (
+	"io"
+	"sync"
+	"encoding/json"
+)
+
+type redactingWriterSink struct {
+	writer      io.Writer
+	minLogLevel LogLevel
+	writeL      *sync.Mutex
+}
+
+func NewRedactingWriterSink(writer io.Writer, minLogLevel LogLevel) Sink {
+	return &writerSink{
+		writer:      writer,
+		minLogLevel: minLogLevel,
+		writeL:      new(sync.Mutex),
+	}
+}
+
+func (sink *redactingWriterSink) Log(log LogFormat) {
+	if log.LogLevel < sink.minLogLevel {
+		return
+	}
+
+	sink.writeL.Lock()
+
+  // first, create a generic object representation of the log data
+	v := log.ToJSON()
+	m := &map[string]interface{}{}
+	json.Unmarshal(v, m)
+
+	// then redact the data before logging it
+
+	sink.writer.Write(log.ToJSON())
+	sink.writer.Write([]byte("\n"))
+	sink.writeL.Unlock()
+}
+
+
+

--- a/redacting_writer_sink_test.go
+++ b/redacting_writer_sink_test.go
@@ -1,0 +1,99 @@
+package lager_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"code.cloudfoundry.org/lager"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RedactingWriterSink", func() {
+	const MaxThreads = 100
+
+	var sink lager.Sink
+	var writer *copyWriter
+
+	BeforeEach(func() {
+		writer = NewCopyWriter()
+		var err error
+		sink, err = lager.NewRedactingWriterSink(writer, lager.INFO, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when logging above the minimum log level", func() {
+		BeforeEach(func() {
+			sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: "hello world", Data: lager.Data{"password": "abcd"}})
+		})
+
+		It("writes to the given writer", func() {
+			Expect(writer.Copy()).To(MatchJSON(`{"message":"hello world","log_level":1,"timestamp":"","source":"","data":{"password":"*REDACTED*"}}`))
+		})
+	})
+
+	Context("when a unserializable object is passed into data", func() {
+		BeforeEach(func() {
+			sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: "hello world", Data: map[string]interface{}{"some_key": func() {}}})
+		})
+
+		It("logs the serialization error", func() {
+			message := map[string]interface{}{}
+			json.Unmarshal(writer.Copy(), &message)
+			Expect(message["message"]).To(Equal("hello world"))
+			Expect(message["log_level"]).To(Equal(float64(1)))
+			Expect(message["data"].(map[string]interface{})["lager serialisation error"]).To(Equal("json: unsupported type: func()"))
+			Expect(message["data"].(map[string]interface{})["data_dump"]).ToNot(BeEmpty())
+		})
+
+		Measure("should be efficient", func(b Benchmarker) {
+			runtime := b.Time("runtime", func() {
+				for i := 0; i < 5000; i++ {
+					sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: "hello world", Data: map[string]interface{}{"some_key": func() {}}})
+					Expect(writer.Copy()).ToNot(BeEmpty())
+				}
+			})
+
+			Expect(runtime.Seconds()).To(BeNumerically("<", 1), "logging shouldn't take too long.")
+		}, 1)
+	})
+
+	Context("when logging below the minimum log level", func() {
+		BeforeEach(func() {
+			sink.Log(lager.LogFormat{LogLevel: lager.DEBUG, Message: "hello world"})
+		})
+
+		It("does not write to the given writer", func() {
+			Expect(writer.Copy()).To(Equal([]byte{}))
+		})
+	})
+
+	Context("when logging from multiple threads", func() {
+		var content = "abcdefg "
+
+		BeforeEach(func() {
+			wg := new(sync.WaitGroup)
+			for i := 0; i < MaxThreads; i++ {
+				wg.Add(1)
+				go func() {
+					sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: content})
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+		})
+
+		It("writes to the given writer", func() {
+			lines := strings.Split(string(writer.Copy()), "\n")
+			for _, line := range lines {
+				if line == "" {
+					continue
+				}
+				Expect(line).To(MatchJSON(fmt.Sprintf(`{"message":"%s","log_level":1,"timestamp":"","source":"","data":null}`, content)))
+			}
+		})
+	})
+})


### PR DESCRIPTION
We created this class as a way to automatically scrub through the output of lager logs and make sure that log output doesn't contain any values with key names containing pwd or password.  We also scrub out any string values that contain amazon keys, private keys, etc.

Regular expressions that match patterns in json keys and values can also be overridden when creating a new writer sink, for processes that may handle different kinds of secrets.

We thought it would be a good idea to PR this back to lager, as it seems generally useful.  If you agree, please let us know and we can add some documentation to the PR.