### PR TITLE
Add Error field to LogFormat

### DIFF
--- a/lagertest/test_sink.go
+++ b/lagertest/test_sink.go
@@ -21,6 +21,7 @@ type TestLogger struct {
 type TestSink struct {
 	lager.Sink
 	buffer *gbytes.Buffer
+	Errors []error
 }
 
 func NewTestLogger(component string) *TestLogger {
@@ -74,4 +75,11 @@ func (s *TestSink) LogMessages() []string {
 		messages = append(messages, log.Message)
 	}
 	return messages
+}
+
+func (s *TestSink) Log(log lager.LogFormat) {
+	if log.Error != nil {
+		s.Errors = append(s.Errors, log.Error)
+	}
+	s.Sink.Log(log)
 }

--- a/logger.go
+++ b/logger.go
@@ -117,6 +117,7 @@ func (l *logger) Error(action string, err error, data ...Data) {
 		Message:   fmt.Sprintf("%s.%s", l.task, action),
 		LogLevel:  ERROR,
 		Data:      logData,
+		Error:     err,
 	}
 
 	for _, sink := range l.sinks {
@@ -143,6 +144,7 @@ func (l *logger) Fatal(action string, err error, data ...Data) {
 		Message:   fmt.Sprintf("%s.%s", l.task, action),
 		LogLevel:  FATAL,
 		Data:      logData,
+		Error:     err,
 	}
 
 	for _, sink := range l.sinks {

--- a/logger_test.go
+++ b/logger_test.go
@@ -251,6 +251,10 @@ var _ = Describe("Logger", func() {
 			It("data contains error message", func() {
 				Expect(testSink.Logs()[0].Data["error"]).To(Equal(err.Error()))
 			})
+
+			It("retains the original error values", func() {
+				Expect(testSink.Errors).To(Equal([]error{err}))
+			})
 		})
 
 		Context("with no log data", func() {
@@ -262,6 +266,10 @@ var _ = Describe("Logger", func() {
 
 			It("data contains error message", func() {
 				Expect(testSink.Logs()[0].Data["error"]).To(Equal(err.Error()))
+			})
+
+			It("retains the original error values", func() {
+				Expect(testSink.Errors).To(Equal([]error{err}))
 			})
 		})
 
@@ -305,6 +313,10 @@ var _ = Describe("Logger", func() {
 			It("panics with the provided error", func() {
 				Expect(fatalErr).To(Equal(err))
 			})
+
+			It("retains the original error values", func() {
+				Expect(testSink.Errors).To(Equal([]error{err}))
+			})
 		})
 
 		Context("with no log data", func() {
@@ -328,6 +340,10 @@ var _ = Describe("Logger", func() {
 
 			It("panics with the provided error", func() {
 				Expect(fatalErr).To(Equal(err))
+			})
+
+			It("retains the original error values", func() {
+				Expect(testSink.Errors).To(Equal([]error{err}))
 			})
 		})
 
@@ -354,5 +370,6 @@ var _ = Describe("Logger", func() {
 				Expect(fatalErr).To(BeNil())
 			})
 		})
+
 	})
 })

--- a/models.go
+++ b/models.go
@@ -22,6 +22,7 @@ type LogFormat struct {
 	Message   string   `json:"message"`
 	LogLevel  LogLevel `json:"log_level"`
 	Data      Data     `json:"data"`
+	Error     error    `json:"-"`
 }
 
 func (log LogFormat) ToJSON() []byte {


### PR DESCRIPTION
Allows Sinks to get at the real error value, rather than just the string

@ematpl 

Use case is building a Sink around something like https://github.com/getsentry/raven-go, so you can report only Errors/Fatals but retain the type information about the underlying error