### PR TITLE
Add redactingPrettySink class for log filtering with formatted timestamps and log level

### DIFF
--- a/lagerflags/lagerflags.go
+++ b/lagerflags/lagerflags.go
@@ -68,18 +68,21 @@ func (t TimeFormat) String() string {
 }
 
 type LagerConfig struct {
-	LogLevel   string     `json:"log_level,omitempty"`
-	TimeFormat TimeFormat `json:"time_format"`
+	LogLevel      string     `json:"log_level,omitempty"`
+	RedactSecrets bool       `json:"redact_secrets,omitempty"`
+	TimeFormat    TimeFormat `json:"time_format"`
 }
 
 func DefaultLagerConfig() LagerConfig {
 	return LagerConfig{
-		LogLevel:   string(INFO),
-		TimeFormat: FormatUnixEpoch,
+		LogLevel:      string(INFO),
+		RedactSecrets: false,
+		TimeFormat:    FormatUnixEpoch,
 	}
 }
 
 var minLogLevel string
+var redactSecrets bool
 var timeFormat TimeFormat
 
 func AddFlags(flagSet *flag.FlagSet) {
@@ -89,11 +92,25 @@ func AddFlags(flagSet *flag.FlagSet) {
 		string(INFO),
 		"log level: debug, info, error or fatal",
 	)
+	flagSet.BoolVar(
+		&redactSecrets,
+		"redactSecrets",
+		false,
+		"use a redacting log sink to scrub sensitive values from data being logged",
+	)
 	flagSet.Var(
 		&timeFormat,
 		"timeFormat",
 		`Format for timestamp in component logs. Valid values are "unix-epoch" and "rfc3339".`,
 	)
+}
+
+func ConfigFromFlags() LagerConfig {
+	return LagerConfig{
+		LogLevel:      minLogLevel,
+		RedactSecrets: redactSecrets,
+		TimeFormat:    timeFormat,
+	}
 }
 
 func New(component string) (lager.Logger, *lager.ReconfigurableSink) {
@@ -106,12 +123,21 @@ func NewFromSink(component string, sink lager.Sink) (lager.Logger, *lager.Reconf
 
 func NewFromConfig(component string, config LagerConfig) (lager.Logger, *lager.ReconfigurableSink) {
 	var sink lager.Sink
-	switch config.TimeFormat {
-	case FormatRFC3339:
-		sink = lager.NewPrettySink(os.Stdout, lager.DEBUG)
-	default:
-		sink = lager.NewWriterSink(os.Stdout, lager.DEBUG)
+
+	if config.RedactSecrets {
+		if config.TimeFormat == FormatRFC3339 {
+			sink, _ = lager.NewRedactingPrettySink(os.Stdout, lager.DEBUG, nil, nil)
+		} else {
+			sink, _ = lager.NewRedactingWriterSink(os.Stdout, lager.DEBUG, nil, nil)
+		}
+	} else {
+		if config.TimeFormat == FormatRFC3339 {
+			sink = lager.NewPrettySink(os.Stdout, lager.DEBUG)
+		} else {
+			sink = lager.NewWriterSink(os.Stdout, lager.DEBUG)
+		}
 	}
+
 	return newLogger(component, config.LogLevel, sink)
 }
 

--- a/lagerflags/lagerflags.go
+++ b/lagerflags/lagerflags.go
@@ -124,23 +124,19 @@ func NewFromSink(component string, sink lager.Sink) (lager.Logger, *lager.Reconf
 func NewFromConfig(component string, config LagerConfig) (lager.Logger, *lager.ReconfigurableSink) {
 	var sink lager.Sink
 
+	if config.TimeFormat == FormatRFC3339 {
+		sink = lager.NewPrettySink(os.Stdout, lager.DEBUG)
+	} else {
+		sink = lager.NewWriterSink(os.Stdout, lager.DEBUG)
+	}
+
 	if config.RedactSecrets {
 		var err error
 
-		if config.TimeFormat == FormatRFC3339 {
-			sink, err = lager.NewRedactingPrettySink(os.Stdout, lager.DEBUG, nil, nil)
-		} else {
-			sink, err = lager.NewRedactingWriterSink(os.Stdout, lager.DEBUG, nil, nil)
-		}
+		sink, err = lager.NewRedactingWrapperSink(sink, nil, nil)
 
 		if err != nil {
 			panic(err)
-		}
-	} else {
-		if config.TimeFormat == FormatRFC3339 {
-			sink = lager.NewPrettySink(os.Stdout, lager.DEBUG)
-		} else {
-			sink = lager.NewWriterSink(os.Stdout, lager.DEBUG)
 		}
 	}
 

--- a/lagerflags/lagerflags.go
+++ b/lagerflags/lagerflags.go
@@ -133,7 +133,7 @@ func NewFromConfig(component string, config LagerConfig) (lager.Logger, *lager.R
 	if config.RedactSecrets {
 		var err error
 
-		sink, err = lager.NewRedactingWrapperSink(sink, nil, nil)
+		sink, err = lager.NewRedactingSink(sink, nil, nil)
 
 		if err != nil {
 			panic(err)

--- a/lagerflags/lagerflags.go
+++ b/lagerflags/lagerflags.go
@@ -125,10 +125,16 @@ func NewFromConfig(component string, config LagerConfig) (lager.Logger, *lager.R
 	var sink lager.Sink
 
 	if config.RedactSecrets {
+		var err error
+
 		if config.TimeFormat == FormatRFC3339 {
-			sink, _ = lager.NewRedactingPrettySink(os.Stdout, lager.DEBUG, nil, nil)
+			sink, err = lager.NewRedactingPrettySink(os.Stdout, lager.DEBUG, nil, nil)
 		} else {
-			sink, _ = lager.NewRedactingWriterSink(os.Stdout, lager.DEBUG, nil, nil)
+			sink, err = lager.NewRedactingWriterSink(os.Stdout, lager.DEBUG, nil, nil)
+		}
+
+		if err != nil {
+			panic(err)
 		}
 	} else {
 		if config.TimeFormat == FormatRFC3339 {

--- a/redacting_writer_sink.go
+++ b/redacting_writer_sink.go
@@ -40,24 +40,24 @@ func (sink *redactingWriterSink) Log(log LogFormat) {
 	sink.writeL.Unlock()
 }
 
-type redactingWrapperSink struct {
+type redactingSink struct {
 	sink         Sink
 	jsonRedacter *JSONRedacter
 }
 
-func NewRedactingWrapperSink(sink Sink, keyPatterns []string, valuePatterns []string) (Sink, error) {
+func NewRedactingSink(sink Sink, keyPatterns []string, valuePatterns []string) (Sink, error) {
 	jsonRedacter, err := NewJSONRedacter(keyPatterns, valuePatterns)
 	if err != nil {
 		return nil, err
 	}
 
-	return &redactingWrapperSink{
+	return &redactingSink{
 		sink:         sink,
 		jsonRedacter: jsonRedacter,
 	}, nil
 }
 
-func (sink *redactingWrapperSink) Log(log LogFormat) {
+func (sink *redactingSink) Log(log LogFormat) {
 	rawJSON, err := json.Marshal(log.Data)
 	if err != nil {
 		log.Data = dataForJSONMarhallingError(err, log.Data)

--- a/redacting_writer_sink.go
+++ b/redacting_writer_sink.go
@@ -2,43 +2,7 @@ package lager
 
 import (
 	"encoding/json"
-	"io"
-	"sync"
 )
-
-type redactingWriterSink struct {
-	writer       io.Writer
-	minLogLevel  LogLevel
-	writeL       *sync.Mutex
-	jsonRedacter *JSONRedacter
-}
-
-func NewRedactingWriterSink(writer io.Writer, minLogLevel LogLevel, keyPatterns []string, valuePatterns []string) (Sink, error) {
-	jsonRedacter, err := NewJSONRedacter(keyPatterns, valuePatterns)
-	if err != nil {
-		return nil, err
-	}
-	return &redactingWriterSink{
-		writer:       writer,
-		minLogLevel:  minLogLevel,
-		writeL:       new(sync.Mutex),
-		jsonRedacter: jsonRedacter,
-	}, nil
-}
-
-func (sink *redactingWriterSink) Log(log LogFormat) {
-	if log.LogLevel < sink.minLogLevel {
-		return
-	}
-
-	sink.writeL.Lock()
-	v := log.ToJSON()
-	rv := sink.jsonRedacter.Redact(v)
-
-	sink.writer.Write(rv)
-	sink.writer.Write([]byte("\n"))
-	sink.writeL.Unlock()
-}
 
 type redactingSink struct {
 	sink         Sink

--- a/redacting_writer_sink_test.go
+++ b/redacting_writer_sink_test.go
@@ -87,7 +87,7 @@ var _ = Describe("RedactingWriterSink", func() {
 	})
 })
 
-var _ = Describe("RedactingWrapperSink", func() {
+var _ = Describe("RedactingSink", func() {
 	var (
 		sink     lager.Sink
 		testSink *lagertest.TestSink
@@ -97,7 +97,7 @@ var _ = Describe("RedactingWrapperSink", func() {
 		testSink = lagertest.NewTestSink()
 
 		var err error
-		sink, err = lager.NewRedactingWrapperSink(testSink, nil, nil)
+		sink, err = lager.NewRedactingSink(testSink, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/redacting_writer_sink_test.go
+++ b/redacting_writer_sink_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"code.cloudfoundry.org/lager"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -83,6 +83,85 @@ var _ = Describe("RedactingWriterSink", func() {
 				}
 				Expect(line).To(MatchJSON(fmt.Sprintf(`{"message":"%s","log_level":1,"timestamp":"","source":"","data":null}`, content)))
 			}
+		})
+	})
+})
+
+var _ = Describe("RedactingPrettySink", func() {
+	const MaxThreads = 100
+
+	var sink lager.Sink
+	var writer *copyWriter
+
+	BeforeEach(func() {
+		writer = NewCopyWriter()
+		var err error
+		sink, err = lager.NewRedactingPrettySink(writer, lager.INFO, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when logging above the minimum log level", func() {
+		BeforeEach(func() {
+			expectedTime := time.Unix(0, 0)
+
+			sink.Log(lager.LogFormat{
+				LogLevel:  lager.INFO,
+				Timestamp: formatTimestamp(expectedTime),
+				Message:   "hello world",
+				Data:      lager.Data{"password": "abcd"},
+			})
+		})
+
+		It("writes to the given writer with a formatted timestamp and log level", func() {
+			Expect(writer.Copy()).To(MatchJSON(`{"timestamp":"1970-01-01T00:00:00.000000000Z","level":"info","source":"","message":"hello world","data":{"password":"*REDACTED*"}}`))
+		})
+	})
+
+	Context("when logging below the minimum log level", func() {
+		BeforeEach(func() {
+			sink.Log(lager.LogFormat{LogLevel: lager.DEBUG, Message: "hello world"})
+		})
+
+		It("does not write to the given writer", func() {
+			Expect(writer.Copy()).To(Equal([]byte{}))
+		})
+	})
+
+	Context("when logging from multiple threads", func() {
+		var content = "abcdefg "
+
+		BeforeEach(func() {
+			expectedTime := time.Unix(0, 0)
+
+			wg := new(sync.WaitGroup)
+			for i := 0; i < MaxThreads; i++ {
+				wg.Add(1)
+				go func() {
+					sink.Log(lager.LogFormat{
+						LogLevel:  lager.INFO,
+						Timestamp: formatTimestamp(expectedTime),
+						Message:   content,
+					})
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+		})
+
+		It("writes to the given writer", func() {
+			lines := strings.Split(string(writer.Copy()), "\n")
+			lineCount := 0
+
+			for _, line := range lines {
+				if line == "" {
+					continue
+				}
+
+				Expect(line).To(MatchJSON(fmt.Sprintf(`{"message":"%s","level":"info","timestamp":"1970-01-01T00:00:00.000000000Z","source":"","data":null}`, content)))
+				lineCount++
+			}
+
+			Expect(lineCount).To(Equal(MaxThreads))
 		})
 	})
 })

--- a/redacting_writer_sink_test.go
+++ b/redacting_writer_sink_test.go
@@ -2,90 +2,12 @@ package lager_test
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
-	"sync"
 
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-
-var _ = Describe("RedactingWriterSink", func() {
-	const MaxThreads = 100
-
-	var sink lager.Sink
-	var writer *copyWriter
-
-	BeforeEach(func() {
-		writer = NewCopyWriter()
-		var err error
-		sink, err = lager.NewRedactingWriterSink(writer, lager.INFO, nil, nil)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	Context("when logging above the minimum log level", func() {
-		BeforeEach(func() {
-			sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: "hello world", Data: lager.Data{"password": "abcd"}})
-		})
-
-		It("writes to the given writer", func() {
-			Expect(writer.Copy()).To(MatchJSON(`{"message":"hello world","log_level":1,"timestamp":"","source":"","data":{"password":"*REDACTED*"}}`))
-		})
-	})
-
-	Context("when a unserializable object is passed into data", func() {
-		BeforeEach(func() {
-			sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: "hello world", Data: map[string]interface{}{"some_key": func() {}}})
-		})
-
-		It("logs the serialization error", func() {
-			message := map[string]interface{}{}
-			json.Unmarshal(writer.Copy(), &message)
-			Expect(message["message"]).To(Equal("hello world"))
-			Expect(message["log_level"]).To(Equal(float64(1)))
-			Expect(message["data"].(map[string]interface{})["lager serialisation error"]).To(Equal("json: unsupported type: func()"))
-			Expect(message["data"].(map[string]interface{})["data_dump"]).ToNot(BeEmpty())
-		})
-	})
-
-	Context("when logging below the minimum log level", func() {
-		BeforeEach(func() {
-			sink.Log(lager.LogFormat{LogLevel: lager.DEBUG, Message: "hello world"})
-		})
-
-		It("does not write to the given writer", func() {
-			Expect(writer.Copy()).To(Equal([]byte{}))
-		})
-	})
-
-	Context("when logging from multiple threads", func() {
-		var content = "abcdefg "
-
-		BeforeEach(func() {
-			wg := new(sync.WaitGroup)
-			for i := 0; i < MaxThreads; i++ {
-				wg.Add(1)
-				go func() {
-					sink.Log(lager.LogFormat{LogLevel: lager.INFO, Message: content})
-					wg.Done()
-				}()
-			}
-			wg.Wait()
-		})
-
-		It("writes to the given writer", func() {
-			lines := strings.Split(string(writer.Copy()), "\n")
-			for _, line := range lines {
-				if line == "" {
-					continue
-				}
-				Expect(line).To(MatchJSON(fmt.Sprintf(`{"message":"%s","log_level":1,"timestamp":"","source":"","data":null}`, content)))
-			}
-		})
-	})
-})
 
 var _ = Describe("RedactingSink", func() {
 	var (


### PR DESCRIPTION
Hi,

This PR adds a new redactingPrettySink class to combine the existing ability to redact sensitive information provided by redactingWriterSink with the formatted timestamps and log levels provided by prettySink. The intention is to allow the volume service brokers/drivers to use this new sink when operators opt-in to human-readable timestamps. Currently, we [always create a new redacting sink](https://github.com/cloudfoundry/nfsv3driver/blob/b66d3a57d985993ca2666c20bc1d37aedc1e0850/cmd/nfsv3driver/main.go#L343):
```Go
	sink, err := lager.NewRedactingWriterSink(os.Stdout, lager.DEBUG, nil, nil)
	if err != nil {
		panic(err)
	}
	return lagerflags.NewFromSink("nfs-driver-server", sink)
```
This would change to using the flag config to allow us to make use of the `TimeFormat` flag:
```Go
       lagerConfig := lagerflags.ConfigFromFlags()
       lagerConfig.RedactSecrets = true

       return lagerflags.NewFromConfig("nfs-driver-server", lagerConfig)
```
We are not currently planning to pass the `--redactSecrets` flag via the command-line, but I included support for it for completeness.

Please let me know if you have any questions.

Regards,
Dave