### PR TITLE
Fix invalid entries written by lagger in few corner cases

### DIFF
--- a/chug/chug.go
+++ b/chug/chug.go
@@ -65,7 +65,7 @@ func Chug(reader io.Reader, out chan<- Entry) {
 	scanner := bufio.NewReader(reader)
 	for {
 		line, err := scanner.ReadBytes('\n')
-		if line != nil {
+		if len(line) > 0 {
 			out <- entry(bytes.TrimSuffix(line, []byte{'\n'}))
 		}
 		if err != nil {

--- a/writer_sink.go
+++ b/writer_sink.go
@@ -32,8 +32,7 @@ func (sink *writerSink) Log(log LogFormat) {
 	}
 
 	sink.writeL.Lock()
-	sink.writer.Write(log.ToJSON())
-	sink.writer.Write([]byte("\n"))
+	sink.writer.Write(append(log.ToJSON(), '\n'))
 	sink.writeL.Unlock()
 }
 
@@ -56,7 +55,6 @@ func (sink *prettySink) Log(log LogFormat) {
 	}
 
 	sink.writeL.Lock()
-	sink.writer.Write(log.toPrettyJSON())
-	sink.writer.Write([]byte("\n"))
+	sink.writer.Write(append(log.toPrettyJSON(), '\n'))
 	sink.writeL.Unlock()
 }


### PR DESCRIPTION
Hello,

We (Garden) have noticed lager occasionally writing invalid log entries and we raise this PR to fix them.

1. When `Chugger` is reading from the reader it would check whether the read bytes slice is `nil` and if it is not `nil` it would send an `Entry` on the output channel. As a matter of fact, reading from a reader would never return a `nil` byte slice, it would return an empty slice if no bytes are read. Therefore we now only send an `Entry` if there are any bytes read.

2. When we use a buffered writer in a writer sync it is possible that the `LogFormat` json length (or a set of `LogFormat` json representation) exactly matches the buffer size. Depending on the buffered writer implementation, the buffer may flush immediately when the its buffer size is reached. Having in mind that the writer sync always appends a new line to the log entry in a separate write operation we may come to the situation that the buffer flushes the message and leaves the new line in the buffer. Therefore on a subsequent write operation the writer sink would write a message starting with an unexpected new line. In order to fix this we append the new line to the message and then perform the write in a single operation.

We realise that these two issues are sort of orthogonal and would be happy to split this PR into two if that is better from your point of view.  

cc @georgethebeatle