### PR TITLE
Honor all relevant flags in lagerflags.New

### DIFF
--- a/lagerflags/lagerflags.go
+++ b/lagerflags/lagerflags.go
@@ -116,7 +116,7 @@ func ConfigFromFlags() LagerConfig {
 }
 
 func New(component string) (lager.Logger, *lager.ReconfigurableSink) {
-	return newLogger(component, minLogLevel, lager.NewWriterSink(os.Stdout, lager.DEBUG))
+	return NewFromConfig(component, ConfigFromFlags())
 }
 
 func NewFromSink(component string, sink lager.Sink) (lager.Logger, *lager.ReconfigurableSink) {


### PR DESCRIPTION
Previously, lagerflags.New would honor only the logLevel flag. This change uses the ConfigFromFlags helper to extract all the relevant flags into one config and then passes it to NewFromConfig so that the invocations are automatically consistent.

Since the default value for the timeFormat package variable is 0, corresponding to FormatUnixEpoch, and since the default value for redactSecrets is false, this default configuration is consistent with the previous hard-coded behavior.