### PR TITLE
Make redaction patterns configurable

### DIFF
--- a/json_redacter.go
+++ b/json_redacter.go
@@ -22,7 +22,7 @@ func NewJSONRedacter(keyPatterns []string, valuePatterns []string) (*JSONRedacte
 		keyPatterns = []string{"[Pp]wd", "[Pp]ass"}
 	}
 	if valuePatterns == nil {
-		valuePatterns = []string{awsAccessKeyIDPattern, awsSecretAccessKeyPattern, cryptMD5Pattern, cryptSHA256Pattern, cryptSHA512Pattern, privateKeyHeaderPattern}
+		valuePatterns = DefaultValuePatterns()
 	}
 	ret := &JSONRedacter{}
 	for _, v := range keyPatterns {
@@ -108,4 +108,8 @@ func handleError(err error) []byte {
 		panic(err)
 	}
 	return content
+}
+
+func DefaultValuePatterns() []string {
+	return []string{awsAccessKeyIDPattern, awsSecretAccessKeyPattern, cryptMD5Pattern, cryptSHA256Pattern, cryptSHA512Pattern, privateKeyHeaderPattern}
 }

--- a/json_redacter_test.go
+++ b/json_redacter_test.go
@@ -77,4 +77,13 @@ var _ = Describe("JSON Redacter", func() {
 			Expect(resp).To(Equal([]byte(`{"foo":"fooval","secret_stuff":{"password":"*REDACTED*"}}`)))
 		})
 	})
+
+	It("DefaultValuePatterns returns the default set of value patterns", func() {
+		Expect(lager.DefaultValuePatterns()).To(ContainElement(`AKIA[A-Z0-9]{16}`))
+		Expect(lager.DefaultValuePatterns()).To(ContainElement(`KEY["']?\s*(?::|=>|=)\s*["']?[A-Z0-9/\+=]{40}["']?`))
+		Expect(lager.DefaultValuePatterns()).To(ContainElement(`\$1\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{22}`))
+		Expect(lager.DefaultValuePatterns()).To(ContainElement(`\$5\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{43}`))
+		Expect(lager.DefaultValuePatterns()).To(ContainElement(`\$6\$[A-Z0-9./]{1,16}\$[A-Z0-9./]{86}`))
+		Expect(lager.DefaultValuePatterns()).To(ContainElement(`-----BEGIN(.*)PRIVATE KEY-----`))
+	})
 })

--- a/lagerflags/lagerflags_test.go
+++ b/lagerflags/lagerflags_test.go
@@ -145,6 +145,22 @@ var _ = Describe("Lagerflags", func() {
 			Eventually(buf).Should(gbytes.Say(`"password":"\*REDACTED\*"`))
 		})
 
+		It("creates a logger that redacts secrets using the supplied redaction regex", func() {
+			buf, origStdout := replaceStdoutWithBuf()
+			defer func() {
+				os.Stdout = origStdout
+			}()
+
+			logger, _ := lagerflags.NewFromConfig("test", lagerflags.LagerConfig{
+				LogLevel:       lagerflags.INFO,
+				RedactSecrets:  true,
+				RedactPatterns: []string{"bar"},
+			})
+
+			logger.Info("hello", lager.Data{"foo": "bar"})
+			Eventually(buf).Should(gbytes.Say(`"foo":"\*REDACTED\*"`))
+		})
+
 		It("creates a logger that truncates long strings", func() {
 			buf, origStdout := replaceStdoutWithBuf()
 			defer func() {

--- a/lagerflags/redact_secrets.go
+++ b/lagerflags/redact_secrets.go
@@ -1,0 +1,14 @@
+package lagerflags
+
+import "strings"
+
+type RedactPatterns []string
+
+func (p *RedactPatterns) String() string {
+	return strings.Join(*p, ",")
+}
+
+func (p *RedactPatterns) Set(value string) error {
+	*p = append(*p, value)
+	return nil
+}

--- a/lagerflags/redact_secrets_test.go
+++ b/lagerflags/redact_secrets_test.go
@@ -1,0 +1,51 @@
+package lagerflags_test
+
+import (
+	"code.cloudfoundry.org/lager/lagerflags"
+	"flag"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RedactSecrets", func() {
+
+	Context("RedactPatterns FlagSet", func() {
+		var flagSet *flag.FlagSet
+		var pattern lagerflags.RedactPatterns
+
+		BeforeEach(func() {
+			flagSet = flag.NewFlagSet("test", flag.ContinueOnError)
+			flagSet.Usage = func() {}
+			flagSet.SetOutput(nopWriter{})
+			flagSet.Var(
+				&pattern,
+				"pattern",
+				`redaction pattern`,
+			)
+		})
+
+		It("parses successfully when no flag is supplied", func() {
+			Expect(flagSet.Parse([]string{})).To(Succeed())
+			Expect(pattern).To(BeNil())
+		})
+
+		It("parses successfully when one flag is supplied", func() {
+			Expect(flagSet.Parse([]string{"-pattern", "foo"})).To(Succeed())
+			Expect(pattern).To(Equal(lagerflags.RedactPatterns{"foo"}))
+		})
+
+		It("parses successfully when flags are supplied", func() {
+			Expect(flagSet.Parse([]string{
+				"-pattern",
+				"one",
+				"-pattern",
+				"two",
+				"-pattern",
+				"three",
+			})).To(Succeed())
+			Expect(pattern).To(ContainElement("one"))
+			Expect(pattern).To(ContainElement("two"))
+			Expect(pattern).To(ContainElement("three"))
+		})
+	})
+})


### PR DESCRIPTION
[#168814250](https://www.pivotaltracker.com/story/show/168814250)

We would like to make the redacting sink configurable.

Rational behind the implementation: 
1. The `NewJSONRedactor` was public; i.e. I saw it as API, and therefore I chose to maintain its implementation 'as-is' so as not to break any other consumers of this API.  That then mean that consumers who want to specify one, or more, custom redact patterns have to supply ALL patterns, including the existing ones and so these are now publicly available.  This is a little clumsy but maintains backward compatibility.   If you feel this is too clumsy and know it is safe to make a slightly different change (where custom patterns are additive perhaps) then feel free to shout.  Happy to update.
2. Given `redactSecrets` is exposed as a cli option, I decided to add a new lagerflag for the new `redactPatterns` option too but please note we do not plan on actually using this.   This maybe yagni?  

An example of our usage would be as follows:

```
func newLogger() (lager.Logger, *lager.ReconfigurableSink) {
	lagerConfig := lagerflags.ConfigFromFlags()
	lagerConfig.RedactSecrets = true
	lagerConfig.RedactPatterns = CustomRedactPatterns()

	return lagerflags.NewFromConfig("server", lagerConfig)
}

func CustomRedactPatterns() []string {
	return append(lager.DefaultValuePatterns(), `<custom-pattern>`)
}
```

We need this so that we can be a little bit more accurate about the secrets we redact from our logs.

cc /@julian-hj @DennisDenuto