### PR TITLE
Update to v3 and go mod major version convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Instantiate a logger with the name of your component.
 
 ```go
 import (
-  "code.cloudfoundry.org/lager"
+  "code.cloudfoundry.org/lager/v3"
 )
 
 logger := lager.NewLogger("my-app")

--- a/chug/chug.go
+++ b/chug/chug.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/v3"
 )
 
 type Entry struct {

--- a/chug/chug_test.go
+++ b/chug/chug_test.go
@@ -1,12 +1,12 @@
 package chug_test
 
 import (
-	"code.cloudfoundry.org/lager/chug"
+	"code.cloudfoundry.org/lager/v3/chug"
 	"errors"
 	"io"
 	"time"
 
-	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/chug/match_log_entry_test.go
+++ b/chug/match_log_entry_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"code.cloudfoundry.org/lager/chug"
+	"code.cloudfoundry.org/lager/v3/chug"
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 )

--- a/chug/package.go
+++ b/chug/package.go
@@ -1,1 +1,0 @@
-package chug // import "code.cloudfoundry.org/lager/v3/chug"

--- a/chug/package.go
+++ b/chug/package.go
@@ -1,1 +1,1 @@
-package chug // import "code.cloudfoundry.org/lager/chug"
+package chug // import "code.cloudfoundry.org/lager/v3/chug"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module code.cloudfoundry.org/lager
+module code.cloudfoundry.org/lager/v3
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/lager/v3
 
-go 1.18
+go 1.19
 
 require (
 	github.com/onsi/ginkgo/v2 v2.2.0

--- a/internal/truncate/package.go
+++ b/internal/truncate/package.go
@@ -1,1 +1,1 @@
-package truncate // import "code.cloudfoundry.org/lager/internal/truncate"
+package truncate // import "code.cloudfoundry.org/lager/v3/internal/truncate"

--- a/internal/truncate/truncate_test.go
+++ b/internal/truncate/truncate_test.go
@@ -3,7 +3,7 @@ package truncate_test
 import (
 	"unsafe"
 
-	"code.cloudfoundry.org/lager/internal/truncate"
+	"code.cloudfoundry.org/lager/v3/internal/truncate"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/json_redacter_test.go
+++ b/json_redacter_test.go
@@ -1,7 +1,7 @@
 package lager_test
 
 import (
-	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/v3"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/lagerctx/context.go
+++ b/lagerctx/context.go
@@ -5,7 +5,7 @@ package lagerctx
 import (
 	"context"
 
-	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/v3"
 )
 
 // NewContext returns a derived context containing the logger.

--- a/lagerctx/context_test.go
+++ b/lagerctx/context_test.go
@@ -7,9 +7,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagerctx"
-	"code.cloudfoundry.org/lager/lagertest"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagerctx"
+	"code.cloudfoundry.org/lager/v3/lagertest"
 )
 
 var _ = Describe("Lager Context", func() {

--- a/lagerctx/package.go
+++ b/lagerctx/package.go
@@ -1,1 +1,0 @@
-package lagerctx // import "code.cloudfoundry.org/lager/v3/lagerctx"

--- a/lagerctx/package.go
+++ b/lagerctx/package.go
@@ -1,1 +1,1 @@
-package lagerctx // import "code.cloudfoundry.org/lager/lagerctx"
+package lagerctx // import "code.cloudfoundry.org/lager/v3/lagerctx"

--- a/lagerflags/README.md
+++ b/lagerflags/README.md
@@ -17,8 +17,8 @@ import (
     "flag"
     "fmt"
 
-    "code.cloudfoundry.org/lager/lagerflags"
-    "code.cloudfoundry.org/lager"
+    "code.cloudfoundry.org/lager/v3/lagerflags"
+    "code.cloudfoundry.org/lager/v3"
 )
 
 func main() {

--- a/lagerflags/integration/integration_suite_test.go
+++ b/lagerflags/integration/integration_suite_test.go
@@ -19,7 +19,7 @@ func TestIntegration(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	var err error
-	testBinary, err = gexec.Build("code.cloudfoundry.org/lager/lagerflags/integration", "-race")
+	testBinary, err = gexec.Build("code.cloudfoundry.org/lager/v3/lagerflags/integration", "-race")
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/lagerflags/integration/main.go
+++ b/lagerflags/integration/main.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"flag"
 
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagerflags"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagerflags"
 )
 
 func main() {

--- a/lagerflags/integration/package.go
+++ b/lagerflags/integration/package.go
@@ -1,1 +1,1 @@
-package main // import "code.cloudfoundry.org/lager/lagerflags/integration"
+package main // import "code.cloudfoundry.org/lager/v3/lagerflags/integration"

--- a/lagerflags/lagerflags.go
+++ b/lagerflags/lagerflags.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/v3"
 )
 
 const (

--- a/lagerflags/lagerflags_test.go
+++ b/lagerflags/lagerflags_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagerflags"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagerflags"
 )
 
 // TODO: Allow sink output to be redirected to a dependency injected

--- a/lagerflags/package.go
+++ b/lagerflags/package.go
@@ -1,1 +1,0 @@
-package lagerflags // import "code.cloudfoundry.org/lager/v3/lagerflags"

--- a/lagerflags/package.go
+++ b/lagerflags/package.go
@@ -1,1 +1,1 @@
-package lagerflags // import "code.cloudfoundry.org/lager/lagerflags"
+package lagerflags // import "code.cloudfoundry.org/lager/v3/lagerflags"

--- a/lagerflags/redact_secrets_test.go
+++ b/lagerflags/redact_secrets_test.go
@@ -3,7 +3,7 @@ package lagerflags_test
 import (
 	"flag"
 
-	"code.cloudfoundry.org/lager/lagerflags"
+	"code.cloudfoundry.org/lager/v3/lagerflags"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/lagerflags/timeformat_test.go
+++ b/lagerflags/timeformat_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"code.cloudfoundry.org/lager/lagerflags"
+	"code.cloudfoundry.org/lager/v3/lagerflags"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/lagertest/package.go
+++ b/lagertest/package.go
@@ -1,1 +1,0 @@
-package lagertest // import "code.cloudfoundry.org/lager/v3/lagertest"

--- a/lagertest/package.go
+++ b/lagertest/package.go
@@ -1,1 +1,1 @@
-package lagertest // import "code.cloudfoundry.org/lager/lagertest"
+package lagertest // import "code.cloudfoundry.org/lager/v3/lagertest"

--- a/lagertest/test_sink.go
+++ b/lagertest/test_sink.go
@@ -10,8 +10,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/gbytes"
 
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagerctx"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagerctx"
 )
 
 type TestLogger struct {

--- a/logger_test.go
+++ b/logger_test.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagertest"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagertest"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/package.go
+++ b/package.go
@@ -1,1 +1,1 @@
-package lager // import "code.cloudfoundry.org/lager"
+package lager // import "code.cloudfoundry.org/lager/v3"

--- a/package.go
+++ b/package.go
@@ -1,1 +1,0 @@
-package lager // import "code.cloudfoundry.org/lager/v3"

--- a/reconfigurable_sink_test.go
+++ b/reconfigurable_sink_test.go
@@ -1,8 +1,8 @@
 package lager_test
 
 import (
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagertest"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/redacting_sink_test.go
+++ b/redacting_sink_test.go
@@ -3,8 +3,8 @@ package lager_test
 import (
 	"encoding/json"
 
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagertest"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/truncating_sink.go
+++ b/truncating_sink.go
@@ -1,6 +1,6 @@
 package lager
 
-import "code.cloudfoundry.org/lager/internal/truncate"
+import "code.cloudfoundry.org/lager/v3/internal/truncate"
 
 type truncatingSink struct {
 	sink                Sink

--- a/truncating_sink_test.go
+++ b/truncating_sink_test.go
@@ -1,8 +1,8 @@
 package lager_test
 
 import (
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/lagertest"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/lagertest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/writer_sink_test.go
+++ b/writer_sink_test.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"code.cloudfoundry.org/lager"
-	"code.cloudfoundry.org/lager/chug"
+	"code.cloudfoundry.org/lager/v3"
+	"code.cloudfoundry.org/lager/v3/chug"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
- major update due to change in import path.
- import path changed to fufill go mod specifications
- creating a release to allow easier vendoring

Signed-off-by: Carson Long <lcarson@vmware.com>