### PR TITLE
Update go.mod to use 1.20 for compatibility with ginkgo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/lager/v3
 
-go 1.19
+go 1.20
 
 require (
 	github.com/onsi/ginkgo/v2 v2.13.2


### PR DESCRIPTION
newer versions of Ginkgo required Go to be at 1.20 and above. Bumping the go.mod to reflect that requirement.