### PR TITLE
Fix slog handler to convert attributes of type err to string

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -145,7 +145,11 @@ func processAttr(attr slog.Attr, target map[string]any) {
 	case attr.Key == "":
 		// skip
 	default:
-		target[attr.Key] = rv.Any()
+		if rvAsError, isError := rv.Any().(error); isError {
+			target[attr.Key] = rvAsError.Error()
+		} else {
+			target[attr.Key] = rv.Any()
+		}
 	}
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+        "fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -56,6 +57,20 @@ var _ = Describe("NewHandler", func() {
 				HaveKeyWithValue("baz", float64(42)),
 			),
 			"LogLevel": Equal(lager.DEBUG),
+		})))
+	})
+
+	It("logs an error message", func() {
+		slog.New(h).Error("foo", "error", fmt.Errorf("boom"))
+		logs := s.Logs()
+		Expect(logs).To(ConsistOf(MatchFields(IgnoreExtras, Fields{
+			"Source":  Equal("test"),
+			"Message": Equal("test.foo"),
+			"Data": SatisfyAll(
+				HaveLen(1),
+				HaveKeyWithValue("error", "boom"),
+			),
+			"LogLevel": Equal(lager.ERROR),
 		})))
 	})
 


### PR DESCRIPTION
- [ x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Slog [hander](../blob/main/handler.go) does not convert attributes of type `err` to `string`. This behaviour is not compatible with the other parts of the lager library.
This fix tries to make the behaviour consistent without breaking anything else.

Fixes issue #126 .


Backward Compatibility
---------------
Breaking Change? **No**

