### PR TITLE
Adjust tests for golang 1.21+ behavior changes when handling panic(nil)

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -368,7 +369,7 @@ var _ = Describe("Logger", func() {
 			})
 
 			It("panics with the provided error (i.e. nil)", func() {
-				Expect(fatalErr).To(BeNil())
+				Expect(fatalErr).To(MatchError(&runtime.PanicNilError{}))
 			})
 		})
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
go 1.21 stopped returning `nil` when `recover()`ing from a `panic(nil)`. It now returns `runtime.PanicNilError`. 


Backward Compatibility
---------------
Breaking Change? no.