### PR TITLE
fix: slog.Handler log error messages rather than `{}`

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -145,7 +145,19 @@ func processAttr(attr slog.Attr, target map[string]any) {
 	case attr.Key == "":
 		// skip
 	default:
-		target[attr.Key] = rv.Any()
+		target[attr.Key] = processValue(rv)
+	}
+}
+
+// processValue takes an slog.Attr.Value and converts it into something suitable
+// for a lager.Data object. Specifically error objects put into lager.Data objects are rendered
+// as `{}`, so they are converted to strings so that the error message can be read.
+func processValue(val slog.Value) any {
+	switch v := val.Any().(type) {
+	case error:
+		return v.Error()
+	default:
+		return v
 	}
 }
 


### PR DESCRIPTION
When used as an slog.Handler, error objects may be specified as slog.Attr attributes. In general attributes are converted into lager.Data{} maps, but there's a feature of logging lager.Data{} maps which is that error objects (and potentially other objects) are rendered as `{}` rather than a more useful representation. This adds a special case for errors so that they are now converted to strings before being placed in a lager.Data{} map.

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes an issue where errors were being logged as `{}` when they originated from an slog.Attr


Backward Compatibility
---------------
Breaking Change? **No**
