### PR TITLE
Fix go fmt linter error

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -5,10 +5,10 @@ package lager_test
 import (
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
+	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-        "fmt"
 	"log/slog"
 	"strconv"
 	"strings"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
fixes CI issue with go fmt after latest PR merged


Backward Compatibility
---------------
Breaking Change? no